### PR TITLE
Feature/enable docker env

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,11 @@
-FRONTEND_URL="http://localhost:4321"
-BACKEND_URL="http://localhost:2413"
-# BACKEND_URL="https://api.info-compass.net"
+FRONTEND_URL="https://www.info-compass.net"
+BACKEND_URL="https://api.info-compass.net"
 STATS_URL="https://stats.info-compass.net"
-PUBLIC_ITEMS_URL="http://localhost:3003/items"
-# PUBLIC_ITEMS_URL="https://public.info-compass.net/items"
+PUBLIC_ITEMS_URL="https://public.info-compass.net/items"
+
+
+# To do by dev team
+# Test with local backend
+# FRONTEND_URL="http://localhost:4321"
+# BACKEND_URL="http://localhost:2413"
+# PUBLIC_ITEMS_URL="http://localhost:3003/items"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,39 @@
-FROM node:18.0.0-alpine AS template_builder
+From node:18.0.0-alpine AS tplbuilder
+LABEL maintainer "Polar Squad <https://www.polarsquad.com/>"
+
+ARG FRONTEND_THEME
 
 COPY --chown=node ./ /app
+
+RUN apk add git --no-cache && \
+    rm -rf /var/cache/apk/*
 
 USER node
 
 WORKDIR /app
 
-# Install required system packages and dependencies & build the template
+# Install required system packages and dependencies & build the tpl
 
-RUN npm install --legacy-peer-deps && \
-    npm run build -- default
+RUN npm install --legacy-peer-deps
 
-# Copy Generated template to Proxy container
-FROM nginx:1.21.6-alpine
+RUN if [ "$FRONTEND_THEME" != "default" ]; then \
+        git clone https://github.com/InfoCompass/${FRONTEND_THEME}.git custom/${FRONTEND_THEME}; \
+    fi
+
+RUN npm run build -- $FRONTEND_THEME dist
+
+
+# Copy Generated tpl to Proxy container
+
+From nginx:1.21.6-alpine
 # Set working directory to nginx asset directory
 WORKDIR /usr/share/nginx/html
 # Remove default nginx static assets
 RUN rm -rf ./*
-COPY --chown=nginx --from=template_builder /app/dev /usr/share/nginx/html
+#COPY --chown=root ./nginx/default.conf /etc/nginx/conf.d
+COPY --chown=nginx --from=tplbuilder /app/build/dist /usr/share/nginx/html
+
+#RUN ls /etc/nginx/conf.d && cat /etc/nginx/conf.d/default.conf
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# docker-compose for local dev environment
+# version: "3.8"
+services:
+  client:
+    image: infocompassde/infocompass-client:${FRONTEND_THEME:-default}-${TAG:-latest}
+    build:
+      context: ./
+      dockerfile: Dockerfile # base image
+    ports:
+      - 80:80
+      - 443:443
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile # base image
+      args:
+        - FRONTEND_THEME=${THEME:-default}
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
* Adding docker setup for local dev env. By default env-vars pointing to remote backend.
* The setup support most of infocompass frontend themes.

PS: Setup with local backend still not working. To fix in the future!